### PR TITLE
Update rate limit policy to set Redis expiry inline with windowMs

### DIFF
--- a/lib/policies/rate-limit/rate-limit.js
+++ b/lib/policies/rate-limit/rate-limit.js
@@ -14,7 +14,8 @@ module.exports = (params) => {
   }
   return new RateLimit(Object.assign(params, {
     store: new RedisStore({
-      client: require('../../db')
+      client: require('../../db'),
+      expiry: params.windowMs / 1000
     })
   }));
 };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "express-gateway",
+  "name": "@mld/express-gateway",
   "version": "1.15.0",
   "description": "A microservices API gateway built on top of ExpressJS",
   "homepage": "https://www.express-gateway.io",
@@ -29,6 +29,9 @@
   "main": "lib/index.js",
   "engines": {
     "node": ">= 8.0.0"
+  },
+  "publishConfig": {
+    "registry": "https://nexus-i.consentric.io:8082/repository/npm-consentric-private/"
   },
   "scripts": {
     "start": "node lib/index.js",


### PR DESCRIPTION
Redis rate limiter expires by default at 60 seconds.

Dividing the `windowMs` into seconds and then passing it through to replace the default expiry: 60 will ensure you get correct rate limiting when storing counters in Redis.

Additionally, for this `@mld` version I have added the nexus registry and prepended `@mld/` on the name for publishing to nexus. 

There is a PR without only the logical change on the Express Gateway repository here https://github.com/ExpressGateway/express-gateway/pull/874 